### PR TITLE
Alinhando conteúdos sobre currículo

### DIFF
--- a/src/views/curriculum/Curriculum.css
+++ b/src/views/curriculum/Curriculum.css
@@ -44,15 +44,17 @@
 
 .list {
   display: flex;
-  flex-wrap: wrap;
+  flex-flow: row nowrap;
   list-style: none;
+  justify-content: space-around;
   margin-bottom: 0;
 }
 
 .list > li {
-  padding: 5.5rem 6.875rem;
+  padding: 5.5rem 3rem;
   text-align: center;
-  width: 50%;
+  flex-grow: 1;
+  flex-basis: 33%;
 }
 
 .list > li > img {
@@ -89,9 +91,6 @@ li.knowledgeMatrix > .button {
 
 li.learningObjectives {
   background: #0bdb9f;
-  padding-left: 17rem;
-  padding-right: 17rem;
-  width: 100%;
 }
 
 .doubleLineHeight {


### PR DESCRIPTION
Solves prefeiturasp/SME-plataforma-curriculo#19.
Antes:
![screenshot from 2018-09-28 01-04-04](https://user-images.githubusercontent.com/3386440/46187658-08604580-c2bb-11e8-82a2-5daa4df306f5.png)
Depois:
![screenshot from 2018-09-28 01-03-56](https://user-images.githubusercontent.com/3386440/46187661-0c8c6300-c2bb-11e8-9761-1b85c95d9172.png)

Eu usei flexbox pra fazer a mudança e ela não causa impacto em telas de viewport de até 768px de largura. No caso limite (769px) ela fica assim:
![screenshot from 2018-09-28 01-11-51](https://user-images.githubusercontent.com/3386440/46187759-87ee1480-c2bb-11e8-828a-a590fd550215.png)

Eu escolhi o padding no eixo x como 2.8rem porque a partir de 2.9rem, quando a tela fica com 769px, um barra de scroll aparece na horizontal, o que é muito chato.