### PR TITLE
 Diminuir o tamanho do rodapé da página

### DIFF
--- a/src/views/footer/Footer.css
+++ b/src/views/footer/Footer.css
@@ -10,18 +10,21 @@
   display: flex;
   justify-content: center;
   padding: 3.75rem;
+  max-height: 9rem;
 }
 
 .logos > img {
   margin: 0 3.75rem;
+  height: 6rem;
+  width: auto;
 }
 
 .license {
   composes: container from global;
   font-size: 0.75rem;
   line-height: 1.125rem;
-  padding-top: 1.625rem;
-  padding-bottom: 2.5rem;
+  padding-top: 0.625rem;
+  padding-bottom: 0.5rem;
 }
 
 .license > a {


### PR DESCRIPTION
Como não está muito bem definido o que é esperado para o rodapé, inicialmente eu pensei em somente reduzir as proporções do objeto, não pensei em nenhuma mudança de forma. 

Reduzi o tamanho de 406,200px para 252,200px que representa aproximadamente 38% menos rodapé

![](https://i.imgur.com/GVgYd7u.png)
