### PR TITLE
Configurando videos incluídos

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,21 @@ body.hasPopup {
 }
 
 .ql-image { width: 100%; }
+.ql-video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  padding-top: 25px;
+  height: 0;
+}
+
+.ql-video-wrapper > iframe {
+  position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
 
 .quill-text h1,
 .quill-text h2,

--- a/src/views/util/convertQuillToHtml.js
+++ b/src/views/util/convertQuillToHtml.js
@@ -23,5 +23,12 @@ export default function convertQuillToHtml(json) {
     }
   });
 
+  converter.afterRender(function(groupType, html) {
+    if (groupType === 'video') {
+      html = `<div class="ql-video-wrapper">${html}</div>`
+    }
+    return html
+  })
+
   return converter.convert();
 }


### PR DESCRIPTION
O pull request https://github.com/prefeiturasp/SME-plataforma-curriculo-API/pull/51 adiciona embed de vídeos no admin.

Antes os vídeos estavam na configuração padrão, o que deixava eles pequenos
<img width="660" alt="screen shot 2018-10-13 at 18 07 37" src="https://user-images.githubusercontent.com/3386440/46910828-e8b75700-cf21-11e8-9c43-a56d85cb8a04.png">
Eu segui o padrão de deixar imagens com `width: 100%` e fiz a mesma coisa no vídeo, o que requer [um hackzinho](https://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php) que assume que os vídeos todos tem ratio 16:9.
<img width="942" alt="screen shot 2018-10-13 at 19 51 06" src="https://user-images.githubusercontent.com/3386440/46910842-1b614f80-cf22-11e8-9e6d-efa3c0ad5f73.png">
