### PR TITLE
Feature/remove component option from filters

### DIFF
--- a/src/reducers/CreateProjectReducer.js
+++ b/src/reducers/CreateProjectReducer.js
@@ -41,7 +41,7 @@ function CreateProjectReducer(state = initialState, action) {
     case CreateProjectActions.LOADED:
       return {
         ...state,
-        curricularComponents: action.data.curricular_components,
+        curricularComponents: action.data.curricular_components.filter((cc) => cc.name !== "Trilhas de Aprendizagens"),
         knowledgeMatrices: action.data.knowledge_matrices,
         studentProtagonisms: action.data.student_protagonisms,
         segments: action.data.segments,

--- a/src/reducers/EditProjectReducer.js
+++ b/src/reducers/EditProjectReducer.js
@@ -56,7 +56,7 @@ function EditProjectReducer(state = initialState, action) {
     case EditProjectActions.LOADED_OPTIONS:
       return {
         ...state,
-        curricularComponents: action.data.curricular_components,
+        curricularComponents: action.data.curricular_components.filter((cc) => cc.name !== "Trilhas de Aprendizagens"),
         knowledgeMatrices: action.data.knowledge_matrices,
         studentProtagonisms: action.data.student_protagonisms,
         segments: action.data.segments,

--- a/src/views/profile/projects/GridItem.js
+++ b/src/views/profile/projects/GridItem.js
@@ -53,8 +53,8 @@ class GridItem extends React.PureComponent {
             <p>{summary}</p>
           </div>
           <div className={styles.dates}>
-            <h5>Criado em: {item.created_at}</h5>
-            <h5>Atualizadoo em: {item.updated_at}</h5>
+            <h5>Criado: {item.created_at}</h5>
+            <h5>Atualizado: {item.updated_at}</h5>
           </div>
           <div className={styles.infos}>
             <NavLink to={editLink} className={`btn btnSmall btnFullWidth`}>

--- a/src/views/project/Project.js
+++ b/src/views/project/Project.js
@@ -89,7 +89,7 @@ class Project extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if(this.props.data !== prevProps.data) {
-      if(this.props.data.old_project) {
+      if(this.props.data.old_project && !this.props.data.updated_by_admin) {
         this.props.openAlert('Alerta! Em breve esse projeto será ajustado.');
       }
     }
@@ -191,6 +191,8 @@ class Project extends Component {
                 )}
                 <p><b>Professor(es)</b> - {data.teacher_name}</p>
                 <p><b>Estudante(s)</b> - {data.owners}</p>
+                <p><b>Criado em:</b> - {data.owners}</p>
+                <p><b>Atualizado em:</b> - {data.owners}</p>
               </div>
               <br></br>
               <h3>Links relacionados</h3>


### PR DESCRIPTION
# Proposal

This PR aims to render created and updated datetime for projects and remove option from curricular components select.

# Azure card reference

- 32173
- 32165

# Tasks to be reached

- [x] Remove option from curricular component select.
- [x] check if project is updated by admin.